### PR TITLE
Fix executor shutdown conditions

### DIFF
--- a/src/aio_helper.py
+++ b/src/aio_helper.py
@@ -152,5 +152,5 @@ async def run_async(func: Callable, *args, prefer_pool: POOL_TYPE = None, **kwar
 def shutdown():
     if aioProcessExecutor:
         aioProcessExecutor.shutdown(wait=True)
-    if aioProcessExecutor:
+    if aioThreadExecutor:
         aioThreadExecutor.shutdown(wait=False)


### PR DESCRIPTION
## Summary
- ensure shutdown() checks the correct executor

## Testing
- `python3 -m py_compile src/aio_helper.py`

------
https://chatgpt.com/codex/tasks/task_e_68440d5c596c832c959bb158b1501a3f